### PR TITLE
Simplify script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,7 @@ Because [EasyRPG is under GPL3 license](https://github.com/EasyRPG/Player/blob/m
 * java;
 * wget;
 * gradle;
-* imagemagick;
-* libncurses5;
-* gtk-doc.
+* imagemagick.
 
 ## Build game app
 
@@ -27,13 +25,16 @@ git clone https://github.com/EasyRPG/buildscripts.git
 cd buildscripts/android
 ./0_build_everything.sh
 ```
-3. While the script `0_build_everything.sh` is running, create a keystore with `nightly` alias (**not lose or share the `game_certificate.key` file**);
+3. While the script `0_build_everything.sh` is running, create a keystore (**do not lose or share the `game_certificate.key` file**);
 ```sh
-keytool -genkey -v -keystore game_certificate.key -alias nightly -keyalg RSA -keysize 4096 -validity 10000
+keytool -genkey -v -keystore game_certificate.key -alias game_cert -keyalg RSA -keysize 4096 -validity 10000
 ```
 4. Change the variables of `convert_script.sh`;
-5. Fork the [EasyRPG Player](https://github.com/EasyRPG/Player) repository (see [Advice](#code-of-conduct));
-6. After script `0_build_everything.sh` is ended sucessful, change the variable of `5_build_android_port.sh` to set your keystore path (made in step 3) and password;
+5. Fork the [EasyRPG Player](https://github.com/EasyRPG/Player) repository (see [Advice](#advice));
+6. After script `0_build_everything.sh` ended successfully, edit the variables in `5_build_android_port.sh` to set your keystore path (made in step 3) and password;
+- Set ``KEYSTORE_PATH`` to ``$(pwd)/game_certificate.key``
+- Set ``KEYSTORE_PASSWORD`` to the password you entered when creating the key
+- Set ``KEYSTORE_NAME`` to ``game_cert`` (the alias)
 7. Change the remote origin of Player repository and set your forked repo as origin;
 ```sh
 cd buildscripts/android/Player

--- a/convert_script.sh
+++ b/convert_script.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 set -e
 
 # Standalone game variables
@@ -11,14 +13,10 @@ GAME_VERSION_NAME=1.0.0
 GAME_METADATA=$(pwd)/metadata
 GAME_ICON_PATH=$GAME_METADATA/en-US/images/icon.png
 GAME_ICON_PROMOGRAPHIC=$GAME_METADATA/en-US/images/promoGraphic.png
+EASYRPG_PLAYER_FOLDER=$(pwd)/buildscripts/android/Player
 ##############################
 
-EASYRPG_BUILD_ANDROID=$(pwd)/buildscripts/android
-EASYRPG_PLAYER_FOLDER=$EASYRPG_BUILD_ANDROID/Player
 ANDROID_FOLDER=$EASYRPG_PLAYER_FOLDER/builds/android
-#GAME_APK_FOLDER_NAME=$(echo "$GAME_APK_NAME" | sed 's/\./\//g')
-GAME_APK_FOLDER_NAME="com/your/game"
-GAME_APK_NATIVE=$(echo "$GAME_APK_NAME" | sed 's/\./_/g')
 
 cd $EASYRPG_PLAYER_FOLDER
 
@@ -29,63 +27,20 @@ echo "" >> .gitignore
 echo "# Game folder" >> .gitignore
 echo "/builds/android/app/src/main/assets/" >> .gitignore
 
-cd src/platform/android
-
-if [ ! -f $GAME_APK_NATIVE'_player_EasyRpgPlayerActivity.cpp' ]; then
-  git mv 'org_easyrpg_player_player_EasyRpgPlayerActivity.cpp' $GAME_APK_NATIVE'_player_EasyRpgPlayerActivity.cpp'
-  git mv 'org_easyrpg_player_player_EasyRpgPlayerActivity.h' $GAME_APK_NATIVE'_player_EasyRpgPlayerActivity.h'
-  find . -type f -name "*.cpp" -exec sed -i "s|org_easyrpg_player|$GAME_APK_NATIVE|g" {} \;
-  find . -type f -name "*.h" -exec sed -i "s|org_easyrpg_player|$GAME_APK_NATIVE|g" {} \;
-fi
-
-cd ../../../
-
-find . -type f -name "CMakeLists.txt" -exec sed -i "s|org_easyrpg_player|$GAME_APK_NATIVE|g" {} \;
-find . -type f -name "CMakeLists.txt" -exec sed -i "s|org.easyrpg.player|$GAME_APK_NAME|g" {} \;
-
 cd builds/android/app/src/main
 
 # Copy game
 rm -fr assets/game
 cp -r $GAME_FOLDER assets/game
 
-# Change java packages
-if [ ! -d java/$GAME_APK_FOLDER_NAME ]; then
-  echo "hohoh"
-  mkdir -p java/$GAME_APK_FOLDER_NAME
-  git mv java/org/easyrpg/player/* java/$GAME_APK_FOLDER_NAME
-fi
-
-cd ..
-
-# Change jni filenames
-if [ ! -f 'gamebrowser/'$GAME_APK_NATIVE'_game_browser_GameScanner.cpp' ]; then
-  git mv 'gamebrowser/org_easyrpg_player_game_browser_GameScanner.cpp' 'gamebrowser/'$GAME_APK_NATIVE'_game_browser_GameScanner.cpp'
-  git mv 'gamebrowser/org_easyrpg_player_game_browser_GameScanner.h' 'gamebrowser/'$GAME_APK_NATIVE'_game_browser_GameScanner.h'
-  git mv 'jni/src/org_easyrpg_player_player_EasyRpgPlayerActivity.cpp' 'jni/src/'$GAME_APK_NATIVE'_player_EasyRpgPlayerActivity.cpp'
-  git mv 'jni/src/org_easyrpg_player_player_EasyRpgPlayerActivity.h' 'jni/src/'$GAME_APK_NATIVE'_player_EasyRpgPlayerActivity.h'
-fi
-
-# Change jni references
-find . -type f -name "*.cpp" -exec sed -i "s|org_easyrpg_player|$GAME_APK_NATIVE|g" {} \;
-find . -type f -name "*.h" -exec sed -i "s|org_easyrpg_player|$GAME_APK_NATIVE|g" {} \;
-find . -type f -name "*.mk" -exec sed -i "s|org_easyrpg_player|$GAME_APK_NATIVE|g" {} \;
-find . -type f -name "CMakeLists.txt" -exec sed -i "s|org_easyrpg_player|$GAME_APK_NATIVE|g" {} \;
-
-cd main
-
 # Change APK name
-find . -type f -name "*.java" -exec sed -i "s|org\.easyrpg\.player|$GAME_APK_NAME|g" {} \;
-find . -type f -name "*.xml" -exec sed -i "s|org\.easyrpg\.player|$GAME_APK_NAME|g" {} \;
 sed -i "s|org\.easyrpg\.player|$GAME_APK_NAME|g" $ANDROID_FOLDER/app/build.gradle
-sed -i "s|org\.easyrpg\.player|$GAME_APK_NAME|g" $ANDROID_FOLDER/fastlane/Appfile
-sed -i "s|org\.easyrpg\.player|$GAME_APK_NAME|g" AndroidManifest.xml
 
 # Change game name
 sed -i "s|EasyRPG Player|$GAME_NAME|g" res/values/strings.xml
 
 # Change game email
-sed -i "s|easyrpg@easyrpg\.org|$GAME_BUG_REPORT_EMAIL|g" java/$GAME_APK_FOLDER_NAME/player/EasyRpgPlayerActivity.java
+sed -i "s|easyrpg@easyrpg\.org|$GAME_BUG_REPORT_EMAIL|g" java/org/easyrpg/player/player/EasyRpgPlayerActivity.java
 
 # Change game site
 sed -i "s|https://easyrpg\.org/|$GAME_SITE|g" res/layout/browser_nav_header.xml


### PR DESCRIPTION
Sorry this took a while, was busy.

In the meanwhile we simplifed the upstream buildscript a bit, you do not need gtk-doc anymore (that was pulled in harfbuzz, I patched it out). Also ncurses5 is not needed anymore with this version of the NDK.

Fix #2

------

There will be likely a change again later: It is now (almost) possible to launch games embedded into the APK. But due to technical limitations they must be a ZIP archive.